### PR TITLE
Fix invisible alien rows

### DIFF
--- a/main.c
+++ b/main.c
@@ -21,7 +21,7 @@
 #define BULLET_SPEED 10
 #define MAX_BULLETS 128
 
-#define ALIEN_ROWS 5
+#define ALIEN_ROWS 3
 #define ALIEN_COLS 8
 #define ALIEN_WIDTH 40
 #define ALIEN_HEIGHT 20


### PR DESCRIPTION
## Summary
- limit alien formation to three rows to match available bitmaps, removing invisible aliens

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_689fb6d975e48326bd3b9193c6aa27f4