### PR TITLE
Derive ship dimensions from texture to fix stray border lines

### DIFF
--- a/main.c
+++ b/main.c
@@ -14,8 +14,6 @@
 
 #define WIDTH 800
 #define HEIGHT 600
-#define SHIP_WIDTH 120
-#define SHIP_HEIGHT 40
 #define SHIP_SPEED 5
 
 #define BULLET_WIDTH 4
@@ -412,7 +410,9 @@ void draw_hud(SDL_Renderer *renderer) {
 }
 
 void reset_game(void) {
-    ship = (SDL_Rect){(WIDTH - SHIP_WIDTH) / 2, HEIGHT - SHIP_HEIGHT - 10, SHIP_WIDTH, SHIP_HEIGHT};
+    int w, h;
+    SDL_QueryTexture(tex_ship, NULL, NULL, &w, &h);
+    ship = (SDL_Rect){(WIDTH - w) / 2, HEIGHT - h - 10, w, h};
     score = 0;
     lives = 3;
     wave = 1;
@@ -494,7 +494,7 @@ int main(void) {
                 } else if (key == SDLK_SPACE && active) {
                     if (count_active_player_bullets() < 3 && player_bullet_count < MAX_BULLETS) {
                         player_bullets[player_bullet_count++] =
-                            (SDL_Rect){ship.x + SHIP_WIDTH / 2 - BULLET_WIDTH / 2,
+                            (SDL_Rect){ship.x + ship.w / 2 - BULLET_WIDTH / 2,
                                        ship.y - BULLET_HEIGHT, BULLET_WIDTH, BULLET_HEIGHT};
                         muzzle_timer = 50;
                         enqueue_sound(SND_PLAYER_SHOT);
@@ -513,7 +513,7 @@ int main(void) {
             }
             if (state[SDL_SCANCODE_RIGHT]) {
                 ship.x += SHIP_SPEED;
-                if (ship.x > WIDTH - SHIP_WIDTH) ship.x = WIDTH - SHIP_WIDTH;
+                if (ship.x > WIDTH - ship.w) ship.x = WIDTH - ship.w;
             }
 
             int alive_count = 0;
@@ -604,13 +604,13 @@ int main(void) {
         }
 
         if (invuln_timer <= 0 || (SDL_GetTicks() / 100) % 2 == 0) {
-            SDL_Rect dst = {ship.x + shake_x, ship.y + shake_y, SHIP_WIDTH, SHIP_HEIGHT};
+            SDL_Rect dst = {ship.x + shake_x, ship.y + shake_y, ship.w, ship.h};
             SDL_RenderCopy(renderer, tex_ship, NULL, &dst);
         }
 
         if (muzzle_timer > 0) {
             SDL_SetRenderDrawColor(renderer, COLOR_PLAYER_BULLET.r, COLOR_PLAYER_BULLET.g, COLOR_PLAYER_BULLET.b, 255);
-            int cx = ship.x + SHIP_WIDTH / 2 + shake_x;
+            int cx = ship.x + ship.w / 2 + shake_x;
             int cy = ship.y + shake_y;
             SDL_Rect r1 = {cx - 1, cy - 8, 2, 8};
             SDL_Rect r2 = {cx - 4, cy - 4, 8, 2};


### PR DESCRIPTION
## Summary
- derive player ship size from the loaded texture using `SDL_QueryTexture`
- use texture dimensions in movement, bullet spawn, and rendering to prevent side lines
- restore original ship texture

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68ab2df418e08326856c16bf960e606e